### PR TITLE
preparation : 챔피언 로테이션 파싱하기

### DIFF
--- a/SpringGG/src/main/java/com/junho/controller/Controller.java
+++ b/SpringGG/src/main/java/com/junho/controller/Controller.java
@@ -9,8 +9,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.junho.dto.ChampionLotation;
 import com.junho.dto.ChampionMastery;
 import com.junho.dto.Summoner;
+import com.junho.util.ChampionLotationParser;
 import com.junho.util.ChampionMasteryParser;
 import com.junho.util.SummonerParser;
 
@@ -27,12 +29,18 @@ public class Controller {
 		
 		// 숙련도 정보 
 		String id = summoner.getId();
-		System.out.println("id : " + id);
 		ChampionMasteryParser championMasteryParser = new ChampionMasteryParser();
 		List<ChampionMastery> championMasteryList = championMasteryParser.getJsonData(id);
 		
-		for(ChampionMastery c : championMasteryList)
-			System.out.println(c.toString());
+//		for(ChampionMastery c : championMasteryList)
+//			System.out.println(c.toString());
+		
+		
+		// 로테이션 정보
+		ChampionLotationParser championLotationParser = new ChampionLotationParser();
+		ChampionLotation championLotation = championLotationParser.getJsonData();
+		
+//		System.out.println(championLotation.toString());
 		
 		if(summoner != null && !summoner.equals(null)) {
 			return new ResponseEntity<Summoner>(summoner,HttpStatus.OK);

--- a/SpringGG/src/main/java/com/junho/dto/ChampionLotation.java
+++ b/SpringGG/src/main/java/com/junho/dto/ChampionLotation.java
@@ -1,0 +1,41 @@
+package com.junho.dto;
+
+import java.util.List;
+
+public class ChampionLotation {
+	private int maxNewPlayerLevel;
+	private List<Integer> freeChampionIdsForNewPlayers;	
+	private List<Integer> freeChampionIds;
+	
+	public ChampionLotation() {}
+	public ChampionLotation(int maxNewPlayerLevel, List<Integer> freeChampionIdsForNewPlayers,
+			List<Integer> freeChampionIds) {
+		this.maxNewPlayerLevel = maxNewPlayerLevel;
+		this.freeChampionIdsForNewPlayers = freeChampionIdsForNewPlayers;
+		this.freeChampionIds = freeChampionIds;
+	}
+	public int getMaxNewPlayerLevel() {
+		return maxNewPlayerLevel;
+	}
+	public void setMaxNewPlayerLevel(int maxNewPlayerLevel) {
+		this.maxNewPlayerLevel = maxNewPlayerLevel;
+	}
+	public List<Integer> getFreeChampionIdsForNewPlayers() {
+		return freeChampionIdsForNewPlayers;
+	}
+	public void setFreeChampionIdsForNewPlayers(List<Integer> freeChampionIdsForNewPlayers) {
+		this.freeChampionIdsForNewPlayers = freeChampionIdsForNewPlayers;
+	}
+	public List<Integer> getFreeChampionIds() {
+		return freeChampionIds;
+	}
+	public void setFreeChampionIds(List<Integer> freeChampionIds) {
+		this.freeChampionIds = freeChampionIds;
+	}
+	@Override
+	public String toString() {
+		return "ChampionLotation [maxNewPlayerLevel=" + maxNewPlayerLevel + ", freeChampionIdsForNewPlayers="
+				+ freeChampionIdsForNewPlayers + ", freeChampionIds=" + freeChampionIds + "]";
+	}
+	
+}

--- a/SpringGG/src/main/java/com/junho/util/ChampionLotationParser.java
+++ b/SpringGG/src/main/java/com/junho/util/ChampionLotationParser.java
@@ -1,0 +1,43 @@
+package com.junho.util;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.BasicResponseHandler;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.junho.dto.ChampionLotation;
+import com.junho.dto.Summoner;
+
+public class ChampionLotationParser {
+
+	public ChampionLotation getJsonData() {
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		String requestURL 	= "https://kr.api.riotgames.com/lol/platform/v3/champion-rotations?api_key=" + Key.API_KEY;
+		ChampionLotation championLotation 	= null;
+		
+		try {
+			HttpClient client = HttpClientBuilder.create().build(); // HttpClient 생성
+			HttpGet getRequest = new HttpGet(requestURL); //GET 메소드 URL 생성
+			HttpResponse response = client.execute(getRequest);
+	
+			//Response 출력
+			if (response.getStatusLine().getStatusCode() == 200) {
+				ResponseHandler<String> handler = new BasicResponseHandler();
+				String body = handler.handleResponse(response);
+				
+				championLotation = objectMapper.readValue(body, ChampionLotation.class);   // String to Object로 변환
+				 		
+			} else {
+				System.out.println("response is error : " + response.getStatusLine().getStatusCode());
+			}
+			
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return championLotation;
+	}
+}


### PR DESCRIPTION
# Commit Message
## 📆 6/3
### 1. DELETE
   -

### 2. CREATE
   - ChampionLotation.java : 챔피언 로테이션 DTO
   - ChampionLotationParser.java : json 형식으로 챔피언 로테이션 정보를 얻는 파서

### 3. UPDATE
   - Controller.java :
      - 챔피언 로테이션 정보를 조회

# Compare with issue #1 
  - Riot API 파싱
     - [x] champion : 로테이션 정보